### PR TITLE
Fix propagating event with secondary events

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,11 +16,11 @@ function propagate(events, source, dest) {
   var oldEmit =  source.emit;
 
   source.emit = function(eventType) {
-    oldEmit.apply(source, arguments);
-
+    var handled = oldEmit.apply(source, arguments);
     if (! events || ~events.indexOf(eventType)) {
-      dest.emit.apply(dest, arguments);
+      handled = dest.emit.apply(dest, arguments) || handled;
     }
+    return handled;
   }
 
   function end() {

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,5 +1,6 @@
 var test = require('tap').test;
 var EventEmitter = require('events').EventEmitter;
+var http = require('http');
 var propagate = require('..');
 
 test('propagates events', function(t) {
@@ -137,4 +138,34 @@ test('is able to propagate and map certain events', function(t) {
   p.end();
 
   ee1.emit('event-1');
+});
+
+test('is able to propagate response from http.ClientRequest', function (t) {
+  t.plan(1);
+
+  var request = http.request({
+    hostname: 'google.com',
+    path: '/',
+    method: 'GET'
+  });
+
+  var ee1 = new EventEmitter();
+
+  propagate(request, ee1);
+
+  var retrievedData = "";
+  ee1.on('response', (response) => {
+
+    response.on('data', (data) => {
+      retrievedData = data.toString('utf8');
+    });
+
+    response.on('close', () => {
+      t.notEqual(retrievedData, "");
+    });
+    
+  });
+
+  request.end();
+
 });


### PR DESCRIPTION
Fix an issue with propagating the return value of an existing listener in order to avoid dumping